### PR TITLE
added a command line option to choose number of threads

### DIFF
--- a/ndpull/__init__.py
+++ b/ndpull/__init__.py
@@ -3,7 +3,7 @@ Python 3 program to download data from NeuroData
 """
 
 
-version = "1.0.0"
+version = "1.0.1"
 
 
 def check_version():

--- a/ndpull/ndpull.py
+++ b/ndpull/ndpull.py
@@ -212,6 +212,7 @@ def collect_args():
 
     parser.add_argument('--print_metadata', action='store_true',
                         help='Prints the metadata on the collection/experiment/channel and quits')
+    parser.add_argument('--threads', default=4, type=int, help='Number of threads for downloading data.')
 
     return parser.parse_args()
 
@@ -336,7 +337,7 @@ def main():
     result, rmt = validate_args(args)
 
     print('Starting download')
-    download_slices(result, rmt)
+    download_slices(result, rmt, threads=args.threads)
     print('Download complete')
 
 


### PR DESCRIPTION
When I tested this locally and used 5 threads instead of 4, I had dramatically improved speeds. With 4 threads, I could download about 5 slices per minute for a certain dataset. When I used 5 threads, it went up to 58 slices per minute.  Not sure if that is a result of number of threads or internet connection. 